### PR TITLE
Include Argent wallets

### DIFF
--- a/DetectContracts.py
+++ b/DetectContracts.py
@@ -1,5 +1,6 @@
 import web3
 import pandas as pd
+import json
 
 w3 = web3.Web3(web3.Web3.HTTPProvider('https://mainnet.infura.io/v3/YOUR-PROJECT-ID'))
 
@@ -9,6 +10,13 @@ def isContract(address):
         return False
     else:
         return True
+
+
+def isArgentWallet(address):
+    abi = json.loads('[{"inputs":[{"internalType":"address","name":"_wallet","type":"address"}],"name":"isArgentWallet","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"}]')
+    argentWalletDetector = w3.eth.contract(address='0xeca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8', abi=abi)
+    return argentWalletDetector.functions.isArgentWallet(address).call()
+
 
 earlyUserFile = 'Compound.EarlyUsers.csv'
 txData = pd.read_csv(earlyUserFile)
@@ -21,7 +29,10 @@ counter = 0
 for address in txData['address']:
     counter += 1
     if isContract(address):
-        addressType.append('contract')
+        if isArgentWallet(address):
+            addressType.append('EOA')
+        else:
+            addressType.append('contract')
     else:
         addressType.append('EOA')
 txData['addressType'] = addressType


### PR DESCRIPTION
This PR updates the `DetectContracts.py` script to identify Argent wallets and flag them as `EOA` in `Compound.EarlyUsers.AccountType.csv`. Argent wallets are identified by calling the `isArgentWallet(address)` method on the `ArgentWalletDetector` contract deployed at [0xeca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8](https://etherscan.io/address/0xeca4B0bDBf7c55E9b7925919d03CbF8Dc82537E8#code).

Argent integrated Compound natively in early summer 2019 and our users interacted with Compound before there was even 100m$ locked into the protocol. Argent wallets are smart-contracts individual to each user and interact directly with the protocol without any proxy. As such they fit the criteria of the airdrop and should be included.